### PR TITLE
Upgrade binaryen to version_92

### DIFF
--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -207,7 +207,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
         Tool::WasmOpt => {
             Ok(format!(
         "https://github.com/WebAssembly/binaryen/releases/download/{vers}/binaryen-{vers}-{target}.tar.gz",
-        vers = "version_90",
+        vers = "version_92",
         target = target,
             ))
         }


### PR DESCRIPTION
- This version exports `asyncify_get_state` as required by GoogleChromeLabs/asyncify (see WebAssembly/binaryen#2679)
- This version also uses the same artifact names, so minimal code changes are required